### PR TITLE
docs: add CLI reference

### DIFF
--- a/doc/cli-reference.md
+++ b/doc/cli-reference.md
@@ -1,0 +1,39 @@
+# CLI Reference
+
+This guide covers how to run the `erq` command‑line interface.
+
+## Starting the CLI
+
+Run `erq` with a SQLite database file. To execute a script, redirect the file into `erq`:
+
+```shell
+erq your_database.db < query.erq
+```
+
+Interactive mode starts when `erq` is invoked without redirecting a script. You can type queries directly:
+
+```shell
+erq your_database.db
+```
+
+## Options
+
+| Option | Alias | Description |
+|-------|-------|-------------|
+| `--help` | `-h` | show Usage |
+| `--version` | `-v` | show Version |
+| `--load {path}` | `-l` | load extension |
+| `--init {path}` | `-i` | path to initialize Erq file |
+| `--format {mode}` | `-f` | output format |
+| `--db {path}` | (default) | path to SQLite database file |
+| `--var name=value` | – | set global variable |
+
+## Examples
+
+Run one of the sample queries included with the project:
+
+```shell
+node bin/erq-cli.js :memory: < examples/helloworld.erq
+```
+
+This connects to an in‑memory database and prints the result of `examples/helloworld.erq`.

--- a/doc/cli-reference.md
+++ b/doc/cli-reference.md
@@ -20,10 +20,10 @@ erq your_database.db
 
 | Option | Alias | Description |
 |-------|-------|-------------|
-| `--help` | `-h` | show Usage |
-| `--version` | `-v` | show Version |
+| `--help` | `-h` | display usage information |
+| `--version` | `-v` | display version information |
 | `--load {path}` | `-l` | load extension |
-| `--init {path}` | `-i` | path to initialize Erq file |
+| `--init {path}` | `-i` | path to initialization file |
 | `--format {mode}` | `-f` | output format |
 | `--db {path}` | (default) | path to SQLite database file |
 | `--var name=value` | – | set global variable |

--- a/src/options.js
+++ b/src/options.js
@@ -3,10 +3,10 @@ import { fileURLToPath } from "node:url";
 import commandLineArgs from "command-line-args";
 
 export const optionList = [
-  { name: 'help', alias: 'h', type: Boolean, description: 'show Usage' },
-  { name: 'version', alias: 'v', type: Boolean, description: 'show Version' },
+  { name: 'help', alias: 'h', type: Boolean, description: 'display usage information' },
+  { name: 'version', alias: 'v', type: Boolean, description: 'display version information' },
   { name: 'load', alias: 'l', typeLabel: '{underline path}', type: String, lazyMultiple: true, defaultValue: [], description: 'load extension' },
-  { name: 'init', alias: 'i', type: String, typeLabel: '{underline path}', description: 'path to initialize Erq file' },
+  { name: 'init', alias: 'i', type: String, typeLabel: '{underline path}', description: 'path to initialization file' },
   { name: 'format', alias: 'f', type: String, typeLabel: '{underline mode}', description: 'output format' },
   { name: 'db', type: String, typeLabel: '{underline path}', defaultOption: true, description: 'path to SQLite database file' },
   { name: 'var', type: String, typeLabel: '{underline name}={underline value}', lazyMultiple: true, defaultValue: [], description: 'set global variable' },


### PR DESCRIPTION
## Summary
- add CLI reference documenting erq usage and options

## Testing
- `npm run test:unit`
- `node bin/erq-cli.js :memory: < examples/helloworld.erq`


------
https://chatgpt.com/codex/tasks/task_e_68b8729f02b0832da44885675bbefb06